### PR TITLE
Replace log with logrus

### DIFF
--- a/internal/provider/testutils/local_server.go
+++ b/internal/provider/testutils/local_server.go
@@ -2,7 +2,7 @@ package testutils
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/http"
 


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-tls', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
templates
.changes
.release
.github
docs
internal
tools
.git
provider
data-sources
resources
tls_public_key
tls_certificate
tls_cert_request
tls_locally_signed_cert
tls_private_key
tls_self_signed_cert
data-sources
resources
unreleased
workflows
ISSUE_TEMPLATE
data-sources
resources
provider
openssh
fixtures
attribute_plan_modifier_int64
attribute_validator
attribute_plan_modifier_bool
testutils
attribute_plan_modifier_string
objects
info
branches
logs
refs
hooks
1b
31
08
94
65
20
99
9f
4e
b6
78
e6
49
89
1e
44
11
47
7c
07
75
e3
29
f2
3f
71
e7
42
ff
ca
26
19
c2
cb
0b
61
5b
cf
d1
c7
e9
pack
9a
8b
d7
b3
3a
b5
info
e5
a7
3c
56
7d
2b
d4
50
73
6d
27
70
46
88
0c
d5
5e
b1
aa
ab
41
b9
6b
d3
0d
33
39
55
17
77
92
8a
64
7b
cd
5d
2d
45
a1
6f
62
df
4d
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)